### PR TITLE
Support direct `npm` import

### DIFF
--- a/src/Roact.lua
+++ b/src/Roact.lua
@@ -1,8 +1,18 @@
 local container = script.Parent.Parent
 local roactModule = container:FindFirstChild("Roact")
+local Roact = nil
 
 if not roactModule then
-	error("Roact Router failed to find Roact. Did you make sure Roact is in the same folder?")
+	-- If the rbx-ts runtime is around, try loading with that
+	local rbxts = game:GetService("ReplicatedStorage"):FindFirstChild("rbxts_include")
+	if rbxts ~= nil then
+		local TS = require(game:GetService("ReplicatedStorage"):WaitForChild("rbxts_include"):WaitForChild("RuntimeLib"))
+		Roact = TS.import(script, TS.getModule(script, "roact").roact.src)
+	else
+		error("Roact Router failed to find Roact. Did you make sure Roact is in the same folder?")
+	end
+else
+	Roact = require(roactModule)
 end
 
-return require(roactModule)
+return Roact


### PR DESCRIPTION
Per discussion in #2 

I have no idea if the `TS` API is stable or not, but I figure at worst this will failover to how it worked before, so it shouldn't be a regression even if the `TS` API changes.

~(Incidentally, do you have any example usage public anywhere? I think I've almost figured it out, but having a bit of trouble with making a `Router` element)~ Whoops, I was putting the `Router` directly in a `screengui` which it wasn't happy with; my bad