### PR TITLE
Fix Link support (?)

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -1,4 +1,5 @@
 return {
+	Link = require(script.Link),
 	Router = require(script.Router),
 	Route = require(script.Route),
 	Redirect = require(script.Redirect),

--- a/typings/Link.d.ts
+++ b/typings/Link.d.ts
@@ -1,6 +1,6 @@
 import Roact from "@rbxts/roact"
 
-interface LinkProps {
+interface LinkProps extends JsxObject<ImageButton> {
 	path: string
 	state?: any
 }


### PR DESCRIPTION
I think Link might have been accidentally omitted from `init.lua`, and TypeScript was unhappy passing through props for the ImageButton, so I added it to the former and forked the Link props from `JsxObject<ImageButton>` which seems to fix typing-related problems.

Separately, I wonder whether it might make sense to have `Link` default to a `ZIndex` of, say, `100`? It feels a bit gross, so I haven't included it in this PR, but it would allow for HTML-style semantics:

```
					<Link path="/test" Size={new UDim2(0.5, 0, 0.5, 0)}>
						<textlabel Text="Test" Size={new UDim2(1, 0, 1, 0)}></textlabel >
					</Link>
```

Alternatively, perhaps a `TextLink` class that implements the above semantics by wrapping a `TextLabel` within a `Link` and passing any `TextLink` props through to the inner `TextLabel`, except `Size` which is given to the `Link` and `UDim2.new(1, 0, 1, 0)` given to the inner `TextLabel`?

I'm going to go with the latter in my project, but I'm happy to PR it up if you think it would fit in as a standard component