### PR TITLE
Fix import of roact

### DIFF
--- a/src/Roact.lua
+++ b/src/Roact.lua
@@ -7,7 +7,7 @@ if not roactModule then
 	local rbxts = game:GetService("ReplicatedStorage"):FindFirstChild("rbxts_include")
 	if rbxts ~= nil then
 		local TS = require(game:GetService("ReplicatedStorage"):WaitForChild("rbxts_include"):WaitForChild("RuntimeLib"))
-		Roact = TS.import(script, TS.getModule(script, "roact").roact.src)
+		Roact = TS.import(script, TS.getModule(script, "roact").src)
 	else
 		error("Roact Router failed to find Roact. Did you make sure Roact is in the same folder?")
 	end


### PR DESCRIPTION
The import of roact for roblox-ts in Roact.lua isn't working, because roact doesn't have a roact folder within it. 