### PR TITLE
Remove roact-hooks dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,37 @@
 {
 	"name": "@rbxts/roact-router",
-	"version": "1.0.2",
-	"lockfileVersion": 1,
+	"version": "1.0.3",
+	"lockfileVersion": 2,
 	"requires": true,
+	"packages": {
+		"": {
+			"name": "@rbxts/roact-router",
+			"version": "1.0.3",
+			"license": "MIT",
+			"dependencies": {
+				"@rbxts/roact": "^1.3.0-ts.5"
+			},
+			"devDependencies": {
+				"@rbxts/types": "^1.0.390"
+			}
+		},
+		"node_modules/@rbxts/roact": {
+			"version": "1.3.0-ts.15",
+			"resolved": "https://registry.npmjs.org/@rbxts/roact/-/roact-1.3.0-ts.15.tgz",
+			"integrity": "sha512-zjaT4jgJWXulUCORH0AK+uawK1W57nnZLykRU1rKjSL+MWg/wx+EbF7/CVQnrg72xDwujtExaku15vElyjnoIg=="
+		},
+		"node_modules/@rbxts/types": {
+			"version": "1.0.529",
+			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.529.tgz",
+			"integrity": "sha512-WcIW/Z7jPN6IBDXa9zHx3l7l40OLSYBt1Y/vgJJRHY32WPUcECusmGck8ii2PClYOaaJTSQzXgj1Qqi1mxFBAQ==",
+			"dev": true
+		}
+	},
 	"dependencies": {
 		"@rbxts/roact": {
 			"version": "1.3.0-ts.15",
 			"resolved": "https://registry.npmjs.org/@rbxts/roact/-/roact-1.3.0-ts.15.tgz",
 			"integrity": "sha512-zjaT4jgJWXulUCORH0AK+uawK1W57nnZLykRU1rKjSL+MWg/wx+EbF7/CVQnrg72xDwujtExaku15vElyjnoIg=="
-		},
-		"@rbxts/roact-hooks": {
-			"version": "0.2.0-ts.3",
-			"resolved": "https://registry.npmjs.org/@rbxts/roact-hooks/-/roact-hooks-0.2.0-ts.3.tgz",
-			"integrity": "sha512-6Cc6SdLNyONrFf7C1SSOIm+mfNKD5H/UwGU1PBQLAz07Ez50qW3ZOfgi25xzhA0IXCZv7zoRCJiH843u1FPh8w=="
 		},
 		"@rbxts/types": {
 			"version": "1.0.529",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,13 @@
 			"name": "@rbxts/roact-router",
 			"version": "1.0.3",
 			"license": "MIT",
-			"dependencies": {
-				"@rbxts/roact": "^1.4.2-ts.2"
-			},
 			"devDependencies": {
 				"@rbxts/compiler-types": "^1.3.3-types.1",
+				"@rbxts/roact": "^1.4.2-ts.2",
 				"@rbxts/types": "^1.0.608"
+			},
+			"peerDependencies": {
+				"@rbxts/roact": "*"
 			}
 		},
 		"node_modules/@rbxts/compiler-types": {
@@ -25,7 +26,8 @@
 		"node_modules/@rbxts/roact": {
 			"version": "1.4.2-ts.2",
 			"resolved": "https://registry.npmjs.org/@rbxts/roact/-/roact-1.4.2-ts.2.tgz",
-			"integrity": "sha512-tHCVZ03dblnqWR0tkvaP0j+cVaJ5NC6mwjE7IzOyYjevYCQ1FUnWFCCkDoUrMEwyG9OqEWNyiXRx3cX1gwxdIQ=="
+			"integrity": "sha512-tHCVZ03dblnqWR0tkvaP0j+cVaJ5NC6mwjE7IzOyYjevYCQ1FUnWFCCkDoUrMEwyG9OqEWNyiXRx3cX1gwxdIQ==",
+			"dev": true
 		},
 		"node_modules/@rbxts/types": {
 			"version": "1.0.608",
@@ -44,7 +46,8 @@
 		"@rbxts/roact": {
 			"version": "1.4.2-ts.2",
 			"resolved": "https://registry.npmjs.org/@rbxts/roact/-/roact-1.4.2-ts.2.tgz",
-			"integrity": "sha512-tHCVZ03dblnqWR0tkvaP0j+cVaJ5NC6mwjE7IzOyYjevYCQ1FUnWFCCkDoUrMEwyG9OqEWNyiXRx3cX1gwxdIQ=="
+			"integrity": "sha512-tHCVZ03dblnqWR0tkvaP0j+cVaJ5NC6mwjE7IzOyYjevYCQ1FUnWFCCkDoUrMEwyG9OqEWNyiXRx3cX1gwxdIQ==",
+			"dev": true
 		},
 		"@rbxts/types": {
 			"version": "1.0.608",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,34 +9,47 @@
 			"version": "1.0.3",
 			"license": "MIT",
 			"dependencies": {
-				"@rbxts/roact": "^1.3.0-ts.5"
+				"@rbxts/roact": "^1.4.2-ts.2"
 			},
 			"devDependencies": {
-				"@rbxts/types": "^1.0.390"
+				"@rbxts/compiler-types": "^1.3.3-types.1",
+				"@rbxts/types": "^1.0.608"
 			}
 		},
+		"node_modules/@rbxts/compiler-types": {
+			"version": "1.3.3-types.1",
+			"resolved": "https://registry.npmjs.org/@rbxts/compiler-types/-/compiler-types-1.3.3-types.1.tgz",
+			"integrity": "sha512-iWeioe5WziBTnY+FIT7aQ5bimlw81PYZ5d9WO0h1kX3joEigXPQpn2yHGRxzrqIssqQr47Y6fwknklaaQ6IPMQ==",
+			"dev": true
+		},
 		"node_modules/@rbxts/roact": {
-			"version": "1.3.0-ts.15",
-			"resolved": "https://registry.npmjs.org/@rbxts/roact/-/roact-1.3.0-ts.15.tgz",
-			"integrity": "sha512-zjaT4jgJWXulUCORH0AK+uawK1W57nnZLykRU1rKjSL+MWg/wx+EbF7/CVQnrg72xDwujtExaku15vElyjnoIg=="
+			"version": "1.4.2-ts.2",
+			"resolved": "https://registry.npmjs.org/@rbxts/roact/-/roact-1.4.2-ts.2.tgz",
+			"integrity": "sha512-tHCVZ03dblnqWR0tkvaP0j+cVaJ5NC6mwjE7IzOyYjevYCQ1FUnWFCCkDoUrMEwyG9OqEWNyiXRx3cX1gwxdIQ=="
 		},
 		"node_modules/@rbxts/types": {
-			"version": "1.0.529",
-			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.529.tgz",
-			"integrity": "sha512-WcIW/Z7jPN6IBDXa9zHx3l7l40OLSYBt1Y/vgJJRHY32WPUcECusmGck8ii2PClYOaaJTSQzXgj1Qqi1mxFBAQ==",
+			"version": "1.0.608",
+			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.608.tgz",
+			"integrity": "sha512-CVesjKAPhWteNOAhdsP216S76FP1Yi6VTwg7SCB73N33Qjvisl3lKO/nMCA2PyZK5zX/yV0kl+aC8Lftzt6czA==",
 			"dev": true
 		}
 	},
 	"dependencies": {
+		"@rbxts/compiler-types": {
+			"version": "1.3.3-types.1",
+			"resolved": "https://registry.npmjs.org/@rbxts/compiler-types/-/compiler-types-1.3.3-types.1.tgz",
+			"integrity": "sha512-iWeioe5WziBTnY+FIT7aQ5bimlw81PYZ5d9WO0h1kX3joEigXPQpn2yHGRxzrqIssqQr47Y6fwknklaaQ6IPMQ==",
+			"dev": true
+		},
 		"@rbxts/roact": {
-			"version": "1.3.0-ts.15",
-			"resolved": "https://registry.npmjs.org/@rbxts/roact/-/roact-1.3.0-ts.15.tgz",
-			"integrity": "sha512-zjaT4jgJWXulUCORH0AK+uawK1W57nnZLykRU1rKjSL+MWg/wx+EbF7/CVQnrg72xDwujtExaku15vElyjnoIg=="
+			"version": "1.4.2-ts.2",
+			"resolved": "https://registry.npmjs.org/@rbxts/roact/-/roact-1.4.2-ts.2.tgz",
+			"integrity": "sha512-tHCVZ03dblnqWR0tkvaP0j+cVaJ5NC6mwjE7IzOyYjevYCQ1FUnWFCCkDoUrMEwyG9OqEWNyiXRx3cX1gwxdIQ=="
 		},
 		"@rbxts/types": {
-			"version": "1.0.529",
-			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.529.tgz",
-			"integrity": "sha512-WcIW/Z7jPN6IBDXa9zHx3l7l40OLSYBt1Y/vgJJRHY32WPUcECusmGck8ii2PClYOaaJTSQzXgj1Qqi1mxFBAQ==",
+			"version": "1.0.608",
+			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.608.tgz",
+			"integrity": "sha512-CVesjKAPhWteNOAhdsP216S76FP1Yi6VTwg7SCB73N33Qjvisl3lKO/nMCA2PyZK5zX/yV0kl+aC8Lftzt6czA==",
 			"dev": true
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
 		"type": "git",
 		"url": "https://github.com/Reselim/roact-router"
 	},
-	"devDependencies": {
-		"@rbxts/types": "^1.0.390"
-	},
 	"dependencies": {
-		"@rbxts/roact": "^1.3.0-ts.5"
+		"@rbxts/roact": "^1.4.2-ts.2"
+	},
+	"devDependencies": {
+		"@rbxts/compiler-types": "^1.3.3-types.1",
+		"@rbxts/types": "^1.0.608"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
 		"@rbxts/types": "^1.0.390"
 	},
 	"dependencies": {
-		"@rbxts/roact": "^1.3.0-ts.5",
-		"@rbxts/roact-hooks": "^0.2.0-ts.3"
+		"@rbxts/roact": "^1.3.0-ts.5"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
 		"type": "git",
 		"url": "https://github.com/Reselim/roact-router"
 	},
-	"dependencies": {
-		"@rbxts/roact": "^1.4.2-ts.2"
+	"peerDependencies": {
+		"@rbxts/roact": "*"
 	},
 	"devDependencies": {
 		"@rbxts/compiler-types": "^1.3.3-types.1",
+		"@rbxts/roact": "^1.4.2-ts.2",
 		"@rbxts/types": "^1.0.608"
 	}
 }

--- a/typings/hooks.d.ts
+++ b/typings/hooks.d.ts
@@ -1,0 +1,15 @@
+import Roact from "@rbxts/roact";
+
+export interface RoactContext<T> {
+    Provider: Roact.ComponentConstructor<{
+            value: T;
+    }>;
+    Consumer: Roact.ComponentConstructor<{
+            render: (value: T) => Roact.Element | undefined;
+    }>;
+}
+
+export interface Hooks {
+    useContext: <T>(context: RoactContext<T>) => T;
+    useMemo: <T>(createValue: () => T, dependencies?: any[]) => T;
+}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,4 @@
-import Roact from "@rbxts/roact"
+import { RoactContext } from "./hooks"
 
 import Router from "./Router"
 import Route, { RouteRendererProps } from "./Route"
@@ -15,15 +15,6 @@ import useRouteMatch from "./useRouteMatch"
 
 import { Path } from "./Path"
 import { History } from "./History"
-
-interface RoactContext<T> {
-        Provider: Roact.ComponentConstructor<{
-                value: T;
-        }>;
-        Consumer: Roact.ComponentConstructor<{
-                render: (value: T) => Roact.Element | undefined;
-        }>;
-}
 
 interface RouteContext extends RoactContext<RouteRendererProps> {}
 interface RouterContext extends RoactContext<RouterRendererProps> {}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,4 @@
-import { RoactContext } from "@rbxts/roact-hooks"
+import Roact from "@rbxts/roact"
 
 import Router from "./Router"
 import Route, { RouteRendererProps } from "./Route"
@@ -15,6 +15,15 @@ import useRouteMatch from "./useRouteMatch"
 
 import { Path } from "./Path"
 import { History } from "./History"
+
+interface RoactContext<T> {
+        Provider: Roact.ComponentConstructor<{
+                value: T;
+        }>;
+        Consumer: Roact.ComponentConstructor<{
+                render: (value: T) => Roact.Element | undefined;
+        }>;
+}
 
 interface RouteContext extends RoactContext<RouteRendererProps> {}
 interface RouterContext extends RoactContext<RouterRendererProps> {}

--- a/typings/useHistory.d.ts
+++ b/typings/useHistory.d.ts
@@ -1,7 +1,7 @@
-import { CoreHooks } from "@rbxts/roact-hooks"
+import { Hooks } from "./hooks";
 
 import { History } from "./History";
 
-declare function useHistory(hooks: CoreHooks): History
+declare function useHistory(hooks: Pick<Hooks, "useContext">): History
 
 export = useHistory

--- a/typings/useLocation.d.ts
+++ b/typings/useLocation.d.ts
@@ -1,7 +1,7 @@
-import { CoreHooks } from "@rbxts/roact-hooks"
+import { Hooks } from "./hooks"
 
 import { HistoryEntry } from "./History"
 
-declare function useLocation(hooks: CoreHooks): HistoryEntry
+declare function useLocation(hooks: Pick<Hooks, "useContext">): HistoryEntry
 
 export = useLocation

--- a/typings/useParams.d.ts
+++ b/typings/useParams.d.ts
@@ -1,7 +1,7 @@
-import { CoreHooks } from "@rbxts/roact-hooks";
+import { Hooks } from "./hooks";
 
 import { PathMatchResults } from "./Path"
 
-declare function useParams(hooks: CoreHooks): PathMatchResults | undefined
+declare function useParams(hooks: Pick<Hooks, "useContext">): PathMatchResults | undefined
 
 export = useParams

--- a/typings/useRouteMatch.d.ts
+++ b/typings/useRouteMatch.d.ts
@@ -1,10 +1,10 @@
-import { CoreHooks } from "@rbxts/roact-hooks";
+import { Hooks } from "./hooks";
 import { PathMatchOptions, PathMatchResults } from "./Path"
 
 export interface RouteMatchOptions extends PathMatchOptions {
         path: string
 }
 
-declare function useRouteMatch(hooks: CoreHooks, options: RouteMatchOptions): PathMatchResults
+declare function useRouteMatch(hooks: Hooks, options: RouteMatchOptions): PathMatchResults
 
 export default useRouteMatch


### PR DESCRIPTION
Removes the dependency on `@rbxts/roact-hooks`, allowing for an alternate implementation to be used.